### PR TITLE
Fix refact-lsp process restart with relevant settings change

### DIFF
--- a/MultilineGreyText/Options/GeneralOptions.xaml.cs
+++ b/MultilineGreyText/Options/GeneralOptions.xaml.cs
@@ -31,54 +31,68 @@ namespace RefactAI{
         private void pPauseCompletion_Checked(object sender, System.Windows.RoutedEventArgs e){
             General.Instance.PauseCompletion = (bool)pPauseCompletion.IsChecked;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //pause completion checkbox unchecked
         private void pPauseCompletion_Unchecked(object sender, System.Windows.RoutedEventArgs e){
             General.Instance.PauseCompletion = (bool)pPauseCompletion.IsChecked;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //code snippets checked
         private void pTelemetryCodeSnippets_Checked(object sender, System.Windows.RoutedEventArgs e){
             General.Instance.TelemetryCodeSnippets = (bool)pTelemetryCodeSnippets.IsChecked;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //code snippets unchecked
         private void pTelemetryCodeSnippets_Unchecked(object sender, System.Windows.RoutedEventArgs e){
             General.Instance.TelemetryCodeSnippets = (bool)pTelemetryCodeSnippets.IsChecked;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //address url text handler
         private void AddressURL_textChanged(object sender, TextChangedEventArgs args){
             General.Instance.AddressURL = AddressURL.Text;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //api key text handler
         private void APIKey_textChanged(object sender, TextChangedEventArgs args){
             General.Instance.APIKey = APIKey.Text;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //code completion model text handler
         private void CodeCompletionModel_textChanged(object sender, TextChangedEventArgs args){
             General.Instance.CodeCompletionModel = CodeCompletionModel.Text;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //code completion other text handler
         private void CodeCompletionModelOther_textChanged(object sender, TextChangedEventArgs args){
             General.Instance.CodeCompletionModelOther = CodeCompletionModelOther.Text;
             General.Instance.Save();
+            NotifySettingsChanged();
         }
 
         //code completion scratchpad text handler
         private void CodeCompletionScratchpad_textChanged(object sender, TextChangedEventArgs args){
             General.Instance.CodeCompletionScratchpad = CodeCompletionScratchpad.Text;
             General.Instance.Save();
+            NotifySettingsChanged();
+        }
+
+        // Notify settings changes
+        private void NotifySettingsChanged(){
+            // Implementation to notify settings changes
         }
    }
 }

--- a/MultilineGreyText/RefactLanguageClient.cs
+++ b/MultilineGreyText/RefactLanguageClient.cs
@@ -364,5 +364,11 @@ namespace RefactAI{
                 }
             }
         }
+
+        // Method to restart the refact-lsp process
+        public async Task RestartRefactLspProcess(){
+            await StopServerAsync();
+            await ActivateAsync(CancellationToken.None);
+        }
     }
 }

--- a/MultilineGreyText/RefactPackage.cs
+++ b/MultilineGreyText/RefactPackage.cs
@@ -59,6 +59,9 @@ namespace RefactAI{
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress){
             await this.RegisterCommandsAsync();
             await RefactAI.PauseRefactCommand.InitializeAsync(this);
+
+            // Register the settings change notification method
+            General.Instance.Saved += async (sender, e) => await RefactLanguageClient.Instance.RestartRefactLspProcess();
         }
 
         #endregion


### PR DESCRIPTION
Related to #33

Add functionality to restart the `refact-lsp` process upon relevant settings changes.

* **MultilineGreyText/Options/GeneralOptions.xaml.cs**
  - Add `NotifySettingsChanged` method to notify settings changes.
  - Call `NotifySettingsChanged` in each text change handler.
  - Call `NotifySettingsChanged` in each checkbox change handler.

* **MultilineGreyText/RefactLanguageClient.cs**
  - Add `RestartRefactLspProcess` method to stop and start the `refact-lsp` process.

