### PR TITLE
Update plugin settings to match VS Code

### DIFF
--- a/MultilineGreyText/Options/General.cs
+++ b/MultilineGreyText/Options/General.cs
@@ -63,6 +63,12 @@ namespace RefactAI{
         [DefaultValue(false)]
         public bool TelemetryCodeSnippets{ get; set; } = false;
 
+        [Category("Refact Assistant")]
+        [DisplayName("Insecure SSL")]
+        [Description("Allow insecure SSL connections.")]
+        [DefaultValue(false)]
+        public bool InsecureSSL { get; set; } = false;
+
         //enters a message into the log when the options are saved
         public General() : base(){
             Saved += delegate { VS.StatusBar.ShowMessageAsync("Options Saved").FireAndForget(); };

--- a/MultilineGreyText/Options/GeneralOptions.xaml
+++ b/MultilineGreyText/Options/GeneralOptions.xaml
@@ -51,6 +51,11 @@
                 <CheckBox x:Name="pTelemetryCodeSnippets" Content="Send corrected code snippets."
                   IsThreeState="False"
                   Checked="pTelemetryCodeSnippets_Checked" Unchecked="pTelemetryCodeSnippets_Unchecked"/>
+
+                <TextBlock Margin="0 15 0 10">Refactai: <Bold>Insecure SSL</Bold></TextBlock>
+                <CheckBox x:Name="pInsecureSSL" Content="Allow insecure SSL connections."
+                  IsThreeState="False"
+                  Checked="pInsecureSSL_Checked" Unchecked="pInsecureSSL_Unchecked"/>
             </StackPanel>
 
         </Grid>

--- a/MultilineGreyText/Options/GeneralOptions.xaml.cs
+++ b/MultilineGreyText/Options/GeneralOptions.xaml.cs
@@ -17,6 +17,7 @@ namespace RefactAI{
         public void Initialize(){
             pPauseCompletion.IsChecked = General.Instance.PauseCompletion;
             pTelemetryCodeSnippets.IsChecked = General.Instance.TelemetryCodeSnippets;
+            pInsecureSSL.IsChecked = General.Instance.InsecureSSL;
 
             AddressURL.Text = General.Instance.AddressURL;
             APIKey.Text = General.Instance.APIKey;
@@ -48,6 +49,18 @@ namespace RefactAI{
         //code snippets unchecked
         private void pTelemetryCodeSnippets_Unchecked(object sender, System.Windows.RoutedEventArgs e){
             General.Instance.TelemetryCodeSnippets = (bool)pTelemetryCodeSnippets.IsChecked;
+            General.Instance.Save();
+        }
+
+        //insecure SSL checked
+        private void pInsecureSSL_Checked(object sender, System.Windows.RoutedEventArgs e){
+            General.Instance.InsecureSSL = (bool)pInsecureSSL.IsChecked;
+            General.Instance.Save();
+        }
+
+        //insecure SSL unchecked
+        private void pInsecureSSL_Unchecked(object sender, System.Windows.RoutedEventArgs e){
+            General.Instance.InsecureSSL = (bool)pInsecureSSL.IsChecked;
             General.Instance.Save();
         }
 

--- a/MultilineGreyText/RefactLanguageClient.cs
+++ b/MultilineGreyText/RefactLanguageClient.cs
@@ -179,6 +179,9 @@ namespace RefactAI{
 
             args += "--address-url " + (String.IsNullOrWhiteSpace(General.Instance.AddressURL) ? "Refact" : General.Instance.AddressURL) + " ";
             args += "--api-key " + (String.IsNullOrWhiteSpace(General.Instance.APIKey) ? "vs-classic-no-key" : General.Instance.APIKey) + " ";
+            if (General.Instance.InsecureSSL){
+                args += "--insecure-ssl ";
+            }
             args += "--lsp-stdin-stdout 1";
 
             return args;


### PR DESCRIPTION
Related to #32

Add insecure SSL option to plugin settings.

* Add a boolean property `InsecureSSL` with a default value of `false` in `MultilineGreyText/Options/General.cs`.
* Add a checkbox for `InsecureSSL` under the "Refact Assistant" category in `MultilineGreyText/Options/GeneralOptions.xaml`.
* Add event handlers for the `InsecureSSL` checkbox to save the setting in `MultilineGreyText/Options/GeneralOptions.xaml.cs`.
* Update the `GetArgs` method in `MultilineGreyText/RefactLanguageClient.cs` to include the `--insecure-ssl` option if the `InsecureSSL` setting is enabled.

