### PR TITLE
Fix multiline completion to start automatically after hitting Tab

### DIFF
--- a/MultilineGreyText/MultilineGreyTextTagger.cs
+++ b/MultilineGreyText/MultilineGreyTextTagger.cs
@@ -446,6 +446,7 @@ namespace RefactAI{
                 int diff = untrimLine.Length - untrimLine.TrimStart().Length;
                 string whitespace = String.IsNullOrWhiteSpace(untrimLine) ? "" : untrimLine.Substring(0, diff);
                 ReplaceText(whitespace + suggestion.Item1, currentTextLineN);
+                RequestNextPortion(); // Pa8f8
                 return true;
             }
 
@@ -509,6 +510,16 @@ namespace RefactAI{
             //currently all of them for simplicity 
             if (this.TagsChanged != null){
                 this.TagsChanged(this, new SnapshotSpanEventArgs(span)); 
+            }
+        }
+
+        // Request the next portion of multiline completion
+        public void RequestNextPortion(){
+            var key = typeof(RefactCompletionCommandHandler);
+            var props = view.TextBuffer.Properties;
+            if (props.ContainsProperty(key)){
+                var handler = props.GetProperty<RefactCompletionCommandHandler>(key);
+                handler.GetLSPCompletions();
             }
         }
     }

--- a/MultilineGreyText/RefactCompletionCommandHandler.cs
+++ b/MultilineGreyText/RefactCompletionCommandHandler.cs
@@ -219,6 +219,7 @@ namespace RefactAI{
                 if (tagger != null){
                     if (tagger.IsSuggestionActive() && tagger.CompleteText()){                        
                         ClearCompletionSessions();
+                        GetLSPCompletions(); // P5b41
                         return VSConstants.S_OK;
                     }else{
                         tagger.ClearSuggestion();


### PR DESCRIPTION
Related to #30

Add automatic triggering of the next portion of multiline completion after hitting Tab.

* Modify `MultilineGreyText/RefactCompletionCommandHandler.cs` to call `GetLSPCompletions` after `CompleteText` in the `Exec` method.
* Modify `MultilineGreyText/MultilineGreyTextTagger.cs` to add a `RequestNextPortion` method and call it after `CompleteText` in the `CompleteText` method.

